### PR TITLE
Fix incorrect main window size after restored from fullscreen mode

### DIFF
--- a/src/WLMainFrameController+FullScreen.m
+++ b/src/WLMainFrameController+FullScreen.m
@@ -68,7 +68,8 @@
 		
 	// Back up the original frame of _targetView
 	_originalFrame = [_tabView frame];
-	
+	_originalMainFrame = [_mainWindow frame];
+
 	// Get the fittest ratio for the expansion
 	NSRect screenRect = [[NSScreen mainScreen] frame];
 	
@@ -106,6 +107,7 @@
 	
 	[_mainWindow setOpaque:NO];
 	// Move view back
+	[_mainWindow setFrame:_originalMainFrame display:YES];
 	[_tabView setFrame:_originalFrame];
 	[_mainWindow setBackgroundColor:_originalWindowBackgroundColor];
 }

--- a/src/WLMainFrameController.h
+++ b/src/WLMainFrameController.h
@@ -68,6 +68,7 @@
 	// 10.7 Full Screen
 	@private
 	NSRect _originalFrame;
+	NSRect _originalMainFrame;
 	CGFloat _screenRatio;
 	NSColor *_originalWindowBackgroundColor;
 	NSDictionary *_originalSizeParameters;


### PR DESCRIPTION
## Change ##
 - save frame of `mainWindow` before entering fullscreen mode, and restore it after leaving fullscreen mode.

### Before ###

![welly-fullscreen](https://user-images.githubusercontent.com/2656666/33049215-e5decd62-ce99-11e7-9016-5d0d1317f4d3.gif)

### After ###
![welly-fullscreen-fixed](https://user-images.githubusercontent.com/2656666/33049340-94b11e1c-ce9a-11e7-9a7c-7b56a25eb2a5.gif)

