### PR TITLE
Fix: unable to set default encoding

### DIFF
--- a/src/WLGlobalConfig.m
+++ b/src/WLGlobalConfig.m
@@ -339,8 +339,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(WLGlobalConfig);
 }
 
 - (void)setDefaultEncoding:(WLEncoding)value {
-    //force big-5 as default encoding
-    _defaultEncoding = 1;
+    _defaultEncoding = value;
     [[NSUserDefaults standardUserDefaults] setInteger:(NSInteger)value forKey:@"DefaultEncoding"];
 }
 


### PR DESCRIPTION
Fix #26: cannot set default encoding (always Big5 in version 3.1.1.1)